### PR TITLE
Feature/style tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Default table block receives govuk styling
+
 ## [0.1.1] - 2020-05-26
 
 ### Changed

--- a/app/Theme/Tables.php
+++ b/app/Theme/Tables.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Dxw\GovukTheme\Theme;
+
+class Tables implements \Dxw\Iguana\Registerable
+{
+    public function register()
+    {
+        add_filter('render_block', [$this, 'useGovukMarkup'], 10, 2);
+    }
+
+    public function useGovukMarkup($blockContent, $block)
+    {
+        if ($block['blockName'] === 'core/table') {
+            $blockContent = $this->replaceMarkup($blockContent);
+        }
+        return $blockContent;
+    }
+
+    private function replaceMarkup($blockContent)
+    {
+        $elementReplacements = $this->getElementReplacements();
+        foreach ($elementReplacements as $element => $replacement) {
+            $blockContent = str_replace($element, $replacement, $blockContent);
+        }
+        return $blockContent;
+    }
+
+    private function getElementReplacements()
+    {
+        return [
+            '<figure class="wp-block-table">' => '',
+            '</figure>' => '',
+            '<table>' => '<table class="' . apply_filters('govuk_theme_class', 'govuk-table') . '">',
+            '<caption>' => '<caption class="' . apply_filters('govuk_theme_class', 'govuk-table__caption') . '">',
+            '<thead>' => '<thead class="' . apply_filters('govuk_theme_class', 'govuk-table__head') . '">',
+            '<tr>' => '<tr class="' . apply_filters('govuk_theme_class', 'govuk-table__row') . '">',
+            '<th>' => '<th class="' . apply_filters('govuk_theme_class', 'govuk-table__header') . '">',
+            '<tbody>' => '<tbody class="' . apply_filters('govuk_theme_class', 'govuk-table__body') . '">',
+            '<td>' => '<td class="' . apply_filters('govuk_theme_class', 'govuk-table__cell') . '">'
+        ];
+    }
+}

--- a/app/Theme/WpHead.php
+++ b/app/Theme/WpHead.php
@@ -16,7 +16,7 @@ class WpHead implements \Dxw\Iguana\Registerable
         remove_action('wp_print_styles', 'print_emoji_styles');
         remove_action('admin_print_styles', 'print_emoji_styles');
         remove_action('admin_print_scripts', 'print_emoji_detection_script');
-        // Remove extra crap from wp_head
+        // Remove detritus from wp_head
         remove_action('wp_head', 'rsd_link');
         remove_action('wp_head', 'wp_generator');
         remove_action('wp_head', 'wlwmanifest_link');

--- a/app/di.php
+++ b/app/di.php
@@ -22,6 +22,7 @@ $registrar->addInstance(\Dxw\GovukTheme\Theme\TitleTag::class, new \Dxw\GovukThe
 $registrar->addInstance(\Dxw\GovukTheme\Theme\Pagination::class, new \Dxw\GovukTheme\Theme\Pagination(
     $registrar->getInstance(\Dxw\Iguana\Theme\Helpers::class)
 ));
+$registrar->addInstance(new \Dxw\GovukTheme\Theme\WpHead());
 
 // Post types and additional fields
 $registrar->addInstance(\Dxw\GovukTheme\Posts\PostTypes::class, new \Dxw\GovukTheme\Posts\PostTypes());

--- a/app/di.php
+++ b/app/di.php
@@ -1,29 +1,29 @@
 <?php
 
-$registrar->addInstance(\Dxw\Iguana\Theme\Helpers::class, new \Dxw\Iguana\Theme\Helpers());
-$registrar->addInstance(\Dxw\Iguana\Theme\LayoutRegister::class, new \Dxw\Iguana\Theme\LayoutRegister(
+$registrar->addInstance(new \Dxw\Iguana\Theme\Helpers());
+$registrar->addInstance(new \Dxw\Iguana\Theme\LayoutRegister(
     $registrar->getInstance(\Dxw\Iguana\Theme\Helpers::class)
 ));
-$registrar->addInstance(\Dxw\Iguana\Extras\UseAtom::class, new \Dxw\Iguana\Extras\UseAtom());
+$registrar->addInstance(new \Dxw\Iguana\Extras\UseAtom());
 
 // Libraries and support code
-$registrar->addInstance(\Dxw\GovukTheme\Lib\Whippet\TemplateTags::class, new \Dxw\GovukTheme\Lib\Whippet\TemplateTags(
+$registrar->addInstance(new \Dxw\GovukTheme\Lib\Whippet\TemplateTags(
     $registrar->getInstance(\Dxw\Iguana\Theme\Helpers::class)
 ));
 
 // Theme behaviour, media, assets and template tags
-$registrar->addInstance(\Dxw\GovukTheme\Theme\Scripts::class, new \Dxw\GovukTheme\Theme\Scripts(
+$registrar->addInstance(new \Dxw\GovukTheme\Theme\Scripts(
     $registrar->getInstance(\Dxw\Iguana\Theme\Helpers::class)
 ));
-$registrar->addInstance(\Dxw\GovukTheme\Theme\Media::class, new \Dxw\GovukTheme\Theme\Media());
-$registrar->addInstance(\Dxw\GovukTheme\Theme\Menus::class, new \Dxw\GovukTheme\Theme\Menus());
-$registrar->addInstance(\Dxw\GovukTheme\Theme\Widgets::class, new \Dxw\GovukTheme\Theme\Widgets());
-$registrar->addInstance(\Dxw\GovukTheme\Theme\TitleTag::class, new \Dxw\GovukTheme\Theme\TitleTag());
-$registrar->addInstance(\Dxw\GovukTheme\Theme\Pagination::class, new \Dxw\GovukTheme\Theme\Pagination(
+$registrar->addInstance(new \Dxw\GovukTheme\Theme\Media());
+$registrar->addInstance(new \Dxw\GovukTheme\Theme\Menus());
+$registrar->addInstance(new \Dxw\GovukTheme\Theme\Widgets());
+$registrar->addInstance(new \Dxw\GovukTheme\Theme\TitleTag());
+$registrar->addInstance(new \Dxw\GovukTheme\Theme\Pagination(
     $registrar->getInstance(\Dxw\Iguana\Theme\Helpers::class)
 ));
 $registrar->addInstance(new \Dxw\GovukTheme\Theme\WpHead());
 
 // Post types and additional fields
-$registrar->addInstance(\Dxw\GovukTheme\Posts\PostTypes::class, new \Dxw\GovukTheme\Posts\PostTypes());
-$registrar->addInstance(\Dxw\GovukTheme\Posts\CustomFields::class, new \Dxw\GovukTheme\Posts\CustomFields());
+$registrar->addInstance(new \Dxw\GovukTheme\Posts\PostTypes());
+$registrar->addInstance(new \Dxw\GovukTheme\Posts\CustomFields());

--- a/app/di.php
+++ b/app/di.php
@@ -22,6 +22,7 @@ $registrar->addInstance(new \Dxw\GovukTheme\Theme\TitleTag());
 $registrar->addInstance(new \Dxw\GovukTheme\Theme\Pagination(
     $registrar->getInstance(\Dxw\Iguana\Theme\Helpers::class)
 ));
+$registrar->addInstance(new \Dxw\GovukTheme\Theme\Tables());
 $registrar->addInstance(new \Dxw\GovukTheme\Theme\WpHead());
 
 // Post types and additional fields

--- a/spec/theme/tables.spec.php
+++ b/spec/theme/tables.spec.php
@@ -1,0 +1,47 @@
+<?php
+
+describe(\Dxw\GovukTheme\Theme\Tables::class, function () {
+    beforeEach(function () {
+        $this->tables = new \Dxw\GovukTheme\Theme\Tables();
+    });
+
+    it('is registerable', function () {
+        expect($this->tables)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
+    });
+
+    describe('->register()', function () {
+        it('registers the filter', function () {
+            allow('add_filter')->toBeCalled();
+            expect('add_filter')->toBeCalled()->once()->with('render_block', [$this->tables, 'useGovukMarkup'], 10, 2);
+            $this->tables->register();
+        });
+    });
+
+    describe('->useGovukMarkup()', function () {
+        context('this is not a core table block', function () {
+            it('returns the block content unchanged', function () {
+                $block['blockName'] = 'core/paragraph';
+                $blockContent = '<p><table>This will not be changed</table></p>';
+                $result = $this->tables->useGovukMarkup($blockContent, $block);
+                expect($result)->toEqual($blockContent);
+            });
+        });
+        context('this is a core table block', function () {
+            it('updates the markup to add the govuk classes', function () {
+                $block['blockName'] = 'core/table';
+                allow('apply_filters')->toBeCalled()->andRun(function ($a, $b) {
+                    return '_' . $b . '_';
+                });
+                $blockContent = '<table>';
+                $blockContent .= '<caption>A caption</caption>';
+                $blockContent .= '<thead><tr><th>Column 1</th></tr></thead>';
+                $blockContent .= '<tbody><tr><td>Data 1</td></tr></tbody>';
+                $blockContent .= '</table>';
+                $result = $this->tables->useGovukMarkup($blockContent, $block);
+                expect($result)->toEqual(
+                    '<table class="_govuk-table_"><caption class="_govuk-table__caption_">A caption</caption><thead class="_govuk-table__head_"><tr class="_govuk-table__row_"><th class="_govuk-table__header_">Column 1</th></tr></thead><tbody class="_govuk-table__body_"><tr class="_govuk-table__row_"><td class="_govuk-table__cell_">Data 1</td></tr></tbody></table>'
+                );
+            });
+        });
+    });
+});


### PR DESCRIPTION
Gutenberg has a "table" block provided by default, but the HTML it produces does not pick up the styling from the GOVUK Frontend, as it has none of the classes applied.

We therefore had a couple of options:
1. Amend our CSS to style the HTML the block outputs by default to look like a GOVUK-style table
1. Amend the HTML output from the table block, so it includes all the govuk-prefixed classes, and therefore picks up the correct styling.

We've opted for option 2, as it's probably more likely that the CSS rules for those classes will be tweaked in future, rather than that the class names themselves will change. We should therefore be able to e.g. pick up styling tweaks from minor version bumps in the GOVUK Frontend, without having to recompile our own CSS.

There is a risk here, in that if the default HTML output of the Gutenberg table block changes in future (e.g. by adding classes to the table element) our code would not longer identify the elements that should be replaced. So we might want to refactor this in future, to be more flexible (e.g. by doing regular expression replacements, rather than using str_replace(). But this should work for now.

Resolves: #6
Resolves: https://trello.com/c/OTn4G0b4/29-styling-for-tables

Before: 
<img width="810" alt="Screenshot 2021-01-27 at 11 56 34" src="https://user-images.githubusercontent.com/370665/105987841-bef4b080-6096-11eb-9fd1-d1e04a80cfcd.png">

After:
<img width="1003" alt="Screenshot 2021-01-27 at 11 57 27" src="https://user-images.githubusercontent.com/370665/105987904-d59b0780-6096-11eb-9cf7-44aae945ff05.png">

