### PR TITLE
Always load this theme's JS & CSS assets from itself

### DIFF
--- a/app/Theme/Scripts.php
+++ b/app/Theme/Scripts.php
@@ -18,7 +18,7 @@ class Scripts implements \Dxw\Iguana\Registerable
 
     public function getAssetPath($path)
     {
-        return dirname(get_stylesheet_directory_uri()).'/static/'.$path;
+        return dirname(get_template_directory_uri()).'/static/'.$path;
     }
 
     public function assetPath($path)

--- a/spec/theme/scripts.spec.php
+++ b/spec/theme/scripts.spec.php
@@ -28,14 +28,14 @@ describe(\Dxw\GovukTheme\Theme\Scripts::class, function () {
 
     describe('->getAssetPath()', function () {
         it('gets the path of the assets', function () {
-            allow('get_stylesheet_directory_uri')->toBeCalled()->andReturn('http://foo.bar.invalid/cat/dog');
+            allow('get_template_directory_uri')->toBeCalled()->andReturn('http://foo.bar.invalid/cat/dog');
             expect($this->scripts->getAssetPath('meow'))->toEqual('http://foo.bar.invalid/cat/static/meow');
         });
     });
 
     describe('->assetPath()', function () {
         it('echos the path of the assets', function () {
-            allow('get_stylesheet_directory_uri')->toBeCalled()->andReturn('http://foo.bar.invalid/cat/dog');
+            allow('get_template_directory_uri')->toBeCalled()->andReturn('http://foo.bar.invalid/cat/dog');
             ob_start();
             $this->scripts->assetPath('meow');
             $result = ob_get_contents();
@@ -46,7 +46,7 @@ describe(\Dxw\GovukTheme\Theme\Scripts::class, function () {
 
     describe('->wpEnqueueScripts()', function () {
         it('enqueues some of the JavaScript files', function () {
-            allow('get_stylesheet_directory_uri')->toBeCalled()->andReturn('http://a.invalid/zzz');
+            allow('get_template_directory_uri')->toBeCalled()->andReturn('http://a.invalid/zzz');
 
             allow('wp_deregister_script')->toBeCalled();
 
@@ -70,7 +70,7 @@ describe(\Dxw\GovukTheme\Theme\Scripts::class, function () {
 
     describe('->wpPrintScripts()', function () {
         it('prints some elements tags directly', function () {
-            allow('get_stylesheet_directory_uri')->toBeCalled()->andReturn('http://a.invalid/zzz');
+            allow('get_template_directory_uri')->toBeCalled()->andReturn('http://a.invalid/zzz');
             ob_start();
             $this->scripts->wpPrintScripts();
             $result = ob_get_contents();


### PR DESCRIPTION
Before: we loaded the CSS & JS using get_stylesheet_directory_uri(). This meant that when this was a parent theme, those files tried to load from within the child theme.

Now: we load them using get_template_directory_uri(). That means they load from this theme (as the parent), and don't have to be re-enqueued in the child theme.