### PR TITLE
Added back the <figure> tag for the table

### DIFF
--- a/app/Theme/Tables.php
+++ b/app/Theme/Tables.php
@@ -29,8 +29,6 @@ class Tables implements \Dxw\Iguana\Registerable
     private function getElementReplacements()
     {
         return [
-            '<figure class="wp-block-table">' => '',
-            '</figure>' => '',
             '<table>' => '<table class="' . apply_filters('govuk_theme_class', 'govuk-table') . '">',
             '<caption>' => '<caption class="' . apply_filters('govuk_theme_class', 'govuk-table__caption') . '">',
             '<thead>' => '<thead class="' . apply_filters('govuk_theme_class', 'govuk-table__head') . '">',


### PR DESCRIPTION
We decide that it's best to keep the figure for semantics and the wp-block-table class is useful for styling