### PR TITLE
Fix/do not hardcode assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.2.1] - 2021-03-11
+
+### Removed
+- Superfluous meta tag and favicons that were printed directly into the page head, and could not be over-written.
+
 ## [v0.2.0] - 2021-02-23
 
 ### Added

--- a/app/Theme/Scripts.php
+++ b/app/Theme/Scripts.php
@@ -13,7 +13,6 @@ class Scripts implements \Dxw\Iguana\Registerable
     public function register()
     {
         add_action('wp_enqueue_scripts', [$this, 'wpEnqueueScripts']);
-        add_action('wp_print_scripts', [$this, 'wpPrintScripts']);
     }
 
     public function getAssetPath($path)
@@ -49,16 +48,5 @@ class Scripts implements \Dxw\Iguana\Registerable
         wp_enqueue_script('main', $this->getAssetPath('main.min.js'), ['jquery', 'modernizr'], '', true);
 
         wp_enqueue_style('main', $this->getAssetPath('main.min.css'));
-    }
-
-    public function wpPrintScripts()
-    {
-        ?>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-        <link rel="apple-touch-icon-precomposed" href="<?php $this->assetPath('img/apple-touch-icon-precomposed.png') ?>">
-
-        <link rel="icon" type="image/png" href="<?php $this->assetPath('img/shortcut-icon.png') ?>">
-        <?php
     }
 }

--- a/spec/theme/scripts.spec.php
+++ b/spec/theme/scripts.spec.php
@@ -20,7 +20,6 @@ describe(\Dxw\GovukTheme\Theme\Scripts::class, function () {
         it('registers nav scripts', function () {
             allow('add_action')->toBeCalled();
             expect('add_action')->toBeCalled()->once()->with('wp_enqueue_scripts', [$this->scripts, 'wpEnqueueScripts']);
-            expect('add_action')->toBeCalled()->once()->with('wp_print_scripts', [$this->scripts, 'wpPrintScripts']);
 
             $this->scripts->register();
         });
@@ -65,18 +64,6 @@ describe(\Dxw\GovukTheme\Theme\Scripts::class, function () {
             expect('wp_enqueue_style')->toBeCalled()->once()->with('main', 'http://a.invalid/static/main.min.css');
 
             $this->scripts->wpEnqueueScripts();
-        });
-    });
-
-    describe('->wpPrintScripts()', function () {
-        it('prints some elements tags directly', function () {
-            allow('get_template_directory_uri')->toBeCalled()->andReturn('http://a.invalid/zzz');
-            ob_start();
-            $this->scripts->wpPrintScripts();
-            $result = ob_get_contents();
-            ob_end_clean();
-            expect(preg_match_all("/<meta .*>/", $result))->toEqual(1);
-            expect(preg_match_all("/<link .*>/", $result))->toEqual(2);
         });
     });
 });

--- a/templates/style.css
+++ b/templates/style.css
@@ -1,7 +1,7 @@
 /*
  * Theme Name: GovukTheme
  * Author: dxw
- * Version: 0.2.0
+ * Version: 0.2.1
  * Author URI: https://www.dxw.com/
  * License: MIT
  * License URI: https://opensource.org/licenses/MIT


### PR DESCRIPTION
This PR:

* Removes a meta tag and favicons that were printed into the head. These are not needed, and could not be unhooked in child themes.
* Bumps the version to 0.2.1