### PR TITLE
v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.3.0] - 2021-03-16
+
 ### Changed
 - Use standard core functions for pagination, rather than custom class
 

--- a/templates/style.css
+++ b/templates/style.css
@@ -1,7 +1,7 @@
 /*
  * Theme Name: GovukTheme
  * Author: dxw
- * Version: 0.2.1
+ * Version: 0.3.0
  * Author URI: https://www.dxw.com/
  * License: MIT
  * License URI: https://opensource.org/licenses/MIT


### PR DESCRIPTION
This is a minor release rather than a patch, because the markup used for pagination has changed, which could break styling of pagination on any sites using this.

To the best of my knowledge, though, we don't have any sites using pagination with this theme at the moment.