### PR TITLE
Make HTML lang attribute dynamic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- The layout template uses WordPress' `language_attributes()` function to generate its html `lang` attribute, rather than the attribute being hardcoded as `en`.
+
 ## [v0.3.0] - 2021-03-16
 
 ### Changed

--- a/templates/layouts/main.php
+++ b/templates/layouts/main.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="<?php echo apply_filters('govuk_theme_class', 'govuk-template') ?>">
+<html <?php language_attributes() ?> class="<?php echo apply_filters('govuk_theme_class', 'govuk-template') ?>">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">


### PR DESCRIPTION
Before: the attribute was hardcoded as "en"

Now: it is based on the site language set in general > settings.