### PR TITLE
Move <head> content to a partial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Moved `<head>` content to a partial, so it can be over-ridden in a child theme, without needing to over-ride the whole layout template.
+
 ## [v0.4.0] - 2021-06-10
 
 ### Added

--- a/templates/layouts/main.php
+++ b/templates/layouts/main.php
@@ -1,21 +1,7 @@
 <!DOCTYPE html>
 <html <?php language_attributes() ?> class="<?php echo apply_filters('govuk_theme_class', 'govuk-template') ?>">
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="theme-color" content="#0b0c0c">
-
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-
-    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/wp-content/themes/govuk-theme/static/lib/govuk-frontend/govuk/assets/images/favicon.ico" type="image/x-icon">
-    <link rel="mask-icon" href="/assets/images/govuk-mask-icon.svg" color="#0b0c0c">
-    <link rel="apple-touch-icon" sizes="180x180" href="/wp-content/themes/govuk-theme/static/lib/govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-180x180.png">
-    <link rel="apple-touch-icon" sizes="167x167" href="/wp-content/themes/govuk-theme/static/lib/govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-167x167.png">
-    <link rel="apple-touch-icon" sizes="152x152" href="/wp-content/themes/govuk-theme/static/lib/govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-152x152.png">
-    <link rel="apple-touch-icon" href="/wp-content/themes/govuk-theme/static/lib/govuk-frontend/govuk/assets/images/govuk-apple-touch-icon.png">
-
-    <meta property="og:image" content="/wp-content/themes/govuk-theme/static/lib/govuk-frontend/govuk/assets/images/govuk-opengraph-image.png">
-
+    <?php get_template_part('partials/head'); ?>
     <?php wp_head(); ?>
 </head>
 <body <?php body_class('govuk-template__body'); ?>>

--- a/templates/partials/head.php
+++ b/templates/partials/head.php
@@ -1,0 +1,14 @@
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<meta name="theme-color" content="#0b0c0c">
+
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+<link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/wp-content/themes/govuk-theme/static/lib/govuk-frontend/govuk/assets/images/favicon.ico" type="image/x-icon">
+<link rel="mask-icon" href="/assets/images/govuk-mask-icon.svg" color="#0b0c0c">
+<link rel="apple-touch-icon" sizes="180x180" href="/wp-content/themes/govuk-theme/static/lib/govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-180x180.png">
+<link rel="apple-touch-icon" sizes="167x167" href="/wp-content/themes/govuk-theme/static/lib/govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-167x167.png">
+<link rel="apple-touch-icon" sizes="152x152" href="/wp-content/themes/govuk-theme/static/lib/govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-152x152.png">
+<link rel="apple-touch-icon" href="/wp-content/themes/govuk-theme/static/lib/govuk-frontend/govuk/assets/images/govuk-apple-touch-icon.png">
+
+<meta property="og:image" content="/wp-content/themes/govuk-theme/static/lib/govuk-frontend/govuk/assets/images/govuk-opengraph-image.png">


### PR DESCRIPTION
This will allow us to over-ride the head content in a child theme
 without needing to over-ride the entire layout template.