### PR TITLE
Retain accessibility attribute for compiled SVGs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Grunt task option to retain accessible attributes for SVGs when compiled
+
 ## [v0.4.1] - 2021-08-11
 
 ### Changed

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -87,6 +87,9 @@ module.exports = function (grunt) {
     },
 
     image: {
+      options: {
+        svgo: ['--disable', 'removeViewBox', '--disable', 'removeUnknownsAndDefaults']
+      },
       dynamic: {
         files: [{
           expand: true,


### PR DESCRIPTION
Currently, SVGs are stripped of necessary attributes when compiled. This changes the Grunt task file so that compiled SVGs retain any additional attributes, such as `focusable="false"`, and therefore help improve the accessibility of SVGs when they need to be made hidden or visible to assistive technology.