### PR TITLE
Remove rule for only updating prod dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,4 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  allow:
-  - dependency-type: production
   open-pull-requests-limit: 0


### PR DESCRIPTION
The "Allow" rule meant that Dependabot could only open PRs for prod dependencies, even if it was trying to patch a security vulnerability in a dev dependency.

Removing this rule means it can open PRs to fix vulnerabilities in dev dependencies, but the open pull request limit rule will still prevent it opening PRs for non-security updates.