### PR TITLE
Bump govuk-frontend to latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Changed
+- Update `govuk-frontend` to latest version; v5.7.1.
 - Update `cpy-cli` to latest major version; v5.
 - Update `del-cli` to latest major version; v6.
 - Update `imagemin-cli` to latest major version; v8.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "govuk-frontend": "^3.8.1"
+        "govuk-frontend": "^5.7.1"
       },
       "devDependencies": {
         "browserify": "^17.0.0",
@@ -4677,9 +4677,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.12.0.tgz",
-      "integrity": "sha512-+mM8BqEUqsBVSV/ud0dEhE8OmMdhkK53eEUp5YyPN+y3mwcdRnwwP2A2B5qFdFi6E6j/2AYuCG8l5kXD+JXNxA==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.7.1.tgz",
+      "integrity": "sha512-jF1cq5rn57kxZmJRprUZhTQ31zaBBK4b5AyeJaPX3Yhg22lk90Mx/dQLvOk/ycV3wM7e0y+s4IPvb2fFaPlCGg==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "govuk-frontend": "^3.8.1"
+    "govuk-frontend": "^5.7.1"
   },
   "devDependencies": {
     "browserify": "^17.0.0",


### PR DESCRIPTION
## Description

This PR updates `govuk-frontend` to the latest version (`v.5.7.1`). It is a breaking change, with remedial work to follow in subsequent PRs.

**Trello card:** https://trello.com/c/AsQ1F5Lw/493-upgrade-gds-repos-to-govuk-frontend-v570-or-above

## Testing

1. Run `npm install`, to update the package.
2. Run `npm run build` and confirm that you see a whole load of errors due to (now) incorrect file paths!
