### PR TITLE
Update script snippet that helps initiate govuk-frontend JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Changed
+- Update the `<script>` snippet that appends classes to `<body>`, [to initiate `govuk-frontend` JS](https://github.com/alphagov/govuk-frontend/blob/main/CHANGELOG.md#update-the-script-snippet-at-the-top-of-your-body-tag).
 - Replace logo in site header, with Tudor crown.
 - Update copyright logo in site footer.
 - Update favicons and align markup with [govuk-frontend recommendations](https://github.com/alphagov/govuk-frontend/blob/main/CHANGELOG.md#check-your-favicons-app-icons-and-opengraph-image-still-work).

--- a/templates/layouts/main.php
+++ b/templates/layouts/main.php
@@ -6,9 +6,7 @@
 </head>
 <body <?php body_class('govuk-template__body'); ?>>
 
-    <script>
-        document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-    </script>
+    <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
 
     <a href="#main-content" class="<?php echo apply_filters('govuk_theme_class', 'govuk-skip-link') ?>"><?php _e('Skip to main content', 'govuk-theme') ?></a>
 


### PR DESCRIPTION
## Description

This PR ensures that the govuk-frontend JS is successfully initiated, by appending the newly added `govuk-frontend-supported` class to the opening body tag.

**GOV.UK Changelog item:** https://github.com/alphagov/govuk-frontend/blob/main/CHANGELOG.md#update-the-script-snippet-at-the-top-of-your-body-tag

## Testing

1. Ensure the site's header navigation is populated with at lease one item.
2. On the frontend, resize your browser window, to simulate a small-screen device.
3. Confirm that the header navigation items are hidden and can be toggled in to view with the 'Menu' toggle button. This confirms that the govuk-frontend JS is working.