### PR TITLE
Update ubuntu version in workflow to 24.04

### DIFF
--- a/.github/workflows/theme.yml
+++ b/.github/workflows/theme.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   kahlan:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         php-versions: ['7.4']
@@ -29,7 +29,7 @@ jobs:
       - name: Run Kahlan tests
         run: vendor/bin/kahlan
   php-cs-fixer:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         php-versions: ['7.4']

--- a/.github/workflows/theme.yml
+++ b/.github/workflows/theme.yml
@@ -18,7 +18,7 @@ jobs:
         id: composer-cache
         run: |
           echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - uses: actions/cache@v4.1.2
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -43,7 +43,7 @@ jobs:
         id: composer-cache
         run: |
           echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - uses: actions/cache@v4.1.2
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
The workflows were being cancelled due to a scheduled Ubuntu 20.04 retirement. Additionally, it was using an outdated version of `actions/cache`.

This PR addresses both issues by updating Ubuntu to 24.04 and unpinning `actions/cache` to use the latest `v4`.